### PR TITLE
fix for soundcloud cookies block

### DIFF
--- a/src/data/seed.json
+++ b/src/data/seed.json
@@ -2823,7 +2823,7 @@
     "api.soundcloud.com": {
       "dnt": false,
       "heuristicAction": "cookieblock",
-      "nextUpdateTime": 0,
+      "nextUpdateTime": 1574230794071,
       "userAction": ""
     },
     "api.stack-sonar.com": {
@@ -13700,8 +13700,8 @@
     },
     "soundcloud.com": {
       "dnt": false,
-      "heuristicAction": "block",
-      "nextUpdateTime": 0,
+      "heuristicAction": "cookieblock",
+      "nextUpdateTime": 1574230794071,
       "userAction": ""
     },
     "sourcepoint.mgr.consensu.org": {
@@ -16142,7 +16142,7 @@
     },
     "w.soundcloud.com": {
       "dnt": false,
-      "heuristicAction": "block",
+      "heuristicAction": "cookieblock",
       "nextUpdateTime": 1574096758342,
       "userAction": ""
     },

--- a/src/data/socialwidgets.json
+++ b/src/data/socialwidgets.json
@@ -95,13 +95,14 @@
         }
     },
     "SoundCloud": {
-        "domain": "w.soundcloud.com",
+        "domain": "soundcloud.com",
         "buttonSelectors": [
             "iframe[src^='https://w.soundcloud.com/player']"
         ],
         "replacementButton": {
             "details": "",
             "unblockDomains": [
+                "soundcloud.com",
                 "https://w.soundcloud.com/"
             ],
             "imagePath": "badger-play.png",

--- a/src/data/yellowlist.txt
+++ b/src/data/yellowlist.txt
@@ -587,8 +587,10 @@ snapengage.com
 sndcdn.com
 auth.api.sonyentertainmentnetwork.com
 cdn-a.sonyentertainmentnetwork.com
+soundcloud.com
 api.soundcloud.com
 feeds.soundcloud.com
+w.soundcloud.com
 springboardplatform.com
 squarespace.com
 squareup.com


### PR DESCRIPTION
Issue: Soundcloud widget replacement does not seem to be working reliably.
**Fixed by:** 
- yellow-listing soundcloud.com, w.soundcloud.com
- changing the heuristicAction for all soundcloud domain from 'block' to 'cookieblock'
- modify the update time so that it is in the past, so the settings will remain unchanged when trackers are refreshed 
- changing the json for social widgets where not only w.soundcloud.com domain is considered but also soundcloud.com main domain is added for times where a different(older) method of embedding is implemented
### Demonstration
#### Before

<img width="1026" alt="before soundcloud" src="https://user-images.githubusercontent.com/54902916/70348849-2ca5a380-1829-11ea-9c00-ec519c210c26.png">

#### After

<img width="1026" alt="after soundcloud" src="https://user-images.githubusercontent.com/54902916/70348757-fa944180-1828-11ea-9454-ed6ead58544c.png">